### PR TITLE
Send attachment in Markdown format

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You will need four parameters:
 - EMAIL_RECIPIENT: Email address of the recipient
 
 Optional parameters:
-- OUTPUT_MARKDOWN: (true|false) Send email attachment in Markdown format. Default "false"
+- OUTPUT_IN_MARKDOWN: (true|false) Send email attachment in Markdown format. Default "false"
 
 Example:
 ```shell

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ You will need four parameters:
 - GITHUB_BRANCH: Name of the GitHub branch. Default "main"
 - EMAIL_RECIPIENT: Email address of the recipient
 
+Optional parameters:
+- OUTPUT_MARKDOWN: (true|false) Send email attachment in Markdown format. Default "false"
+
 Example:
 ```shell
 oc process -f template-s2i.yaml -p NAMESPACE="mynamespace" -p GITHUB_URL="https://github.com/CSCfi/broken-link-s2i.git" -p GITHUB_BRANCH="otherbranch" -p EMAIL_RECIPIENT="some.address@world.com" | oc apply -f - 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Simply process the file `template-s2i.yaml` to create:
 - Image Stream
 - Cronjob
 
-You will need three parameters:
+You will need four parameters:
 - NAMESPACE: Specify your namespace where you will deploy the template
 - GITHUB_URL: URL of the GitHub repo where to source for building the image
 - GITHUB_BRANCH: Name of the GitHub branch. Default "main"

--- a/app.py
+++ b/app.py
@@ -6,12 +6,12 @@ from email.message import EmailMessage
 from parser.report import Report
 
 
-OUTPUT_MARKDOWN = os.environ['OUTPUT_IN_MARKDOWN'].lower() == "true"
+OUTPUT_IN_MARKDOWN = os.environ['OUTPUT_IN_MARKDOWN'].lower() == "true"
 EMAIL_RECIPIENT = os.environ['EMAIL_RECIPIENT']
 INPUT_FILENAME = "linkchecker-out.xml"
-OUTPUT_FILENAME = "404.md" if OUTPUT_MARKDOWN else "404.txt"
-ATTACHMENT_FILENAME = "report.md" if OUTPUT_MARKDOWN else "report.txt"
-ATTACHMENT_MIME_SUBTYPE = "markdown" if OUTPUT_MARKDOWN else "plain"
+OUTPUT_FILENAME = "404.md" if OUTPUT_IN_MARKDOWN else "404.txt"
+ATTACHMENT_FILENAME = "report.md" if OUTPUT_IN_MARKDOWN else "report.txt"
+ATTACHMENT_MIME_SUBTYPE = "markdown" if OUTPUT_IN_MARKDOWN else "plain"
 URL = "https://docs.csc.fi/"
 
 

--- a/app.py
+++ b/app.py
@@ -27,10 +27,12 @@ report.to_file(OUTPUT_FILENAME)
 
 msg = EmailMessage()
 msg["From"] = "noreply@csc.fi"
-msg["Subject"] = "Broken links report"
+msg["Subject"] = f"Broken links report for {report.month}"
 msg["To"] = os.getenv('EMAIL_RECIPIENT')
-msg.set_content("You will find attached the broken links report of docs.csc.fi")
-msg.add_attachment(open(OUTPUTFILE, "r", encoding="utf-8").read(), subtype='txt', filename='404.txt')
+msg.set_content(f"You will find attached the broken links report of {URL} for {report.month}.")
+msg.add_attachment(open(OUTPUT_FILENAME, "r", encoding="utf-8").read(),
+                   subtype=ATTACHMENT_MIME_SUBTYPE,
+                   filename=ATTACHMENT_FILENAME)
 
 s = smtplib.SMTP('smtp.pouta.csc.fi')
 s.send_message(msg)

--- a/parser/report.py
+++ b/parser/report.py
@@ -1,0 +1,48 @@
+from datetime import date
+import xml.etree.ElementTree as ET
+
+from .result import Result
+
+
+class Report:
+    NOT_FOUND_RESULT = "404 Not Found"
+    NOT_FOUND_XPATH = f"./urldata/*[@result='{NOT_FOUND_RESULT}']/.."
+    XML_TAGS = ("url", "name", "parent")
+
+    def __init__(self, input_filename):
+        self.xml_tree_root = ET.parse(input_filename).getroot()
+        self.month = date.today().strftime("%B %Y")
+
+    @staticmethod
+    def __get_xml_text(elem, tag):
+        return elem.find(tag).text
+
+    @classmethod
+    def __parse_xml_result(cls, elem):
+        return tuple(cls.__get_xml_text(elem, tag)
+                     for tag in cls.XML_TAGS)
+
+    @property
+    def results(self):
+        xml_results = self.xml_tree_root.findall(self.NOT_FOUND_XPATH)
+
+        return [Result(*(*self.__parse_xml_result(result),
+                         self.NOT_FOUND_RESULT))
+                for result in xml_results]
+
+    def __write_markdown(self, fp):
+        md_results = f"## Broken links, {self.month}\n" \
+            + "".join(result.markdown for result in self.results)
+        fp.write(md_results)
+
+    def __write_txt(self, fp):
+        results = "".join(result.txt for result in self.results) \
+            + f"\nProcessed: {len(self.results)}"
+        fp.write(results)
+
+    def to_file(self, output_filename):
+        with open(output_filename, "wt", encoding="utf-8") as output_file:
+            if output_filename.endswith(".md"):
+                self.__write_markdown(output_file)
+            else:
+                self.__write_txt(output_file)

--- a/parser/result.py
+++ b/parser/result.py
@@ -1,0 +1,44 @@
+from string import Template
+
+
+class Result:
+    MD_TEMPLATE = Template("""
+- [ ] Href: **$url**
+    - Name: _${name}_
+    - Parent URL: $parent
+    - Result: `$result`
+"""
+    )
+    TXT_TEMPLATE = Template("""
+URL: $url
+Name: $name
+Parent URL: $parent
+Result: $result
+"""
+    )
+
+    def __init__(self, url, name, parent, result):
+        self.url = url
+        self.name = name
+        self.parent = parent
+        self.result = result
+
+    def __iter__(self):
+        for attr in ("url", "name", "parent", "result"):
+            yield getattr(self, attr)
+
+    def __substitutions(self, template):
+        return template.substitute(
+            url=self.url,
+            name=self.name,
+            parent=self.parent,
+            result=self.result
+        )
+
+    @property
+    def txt(self):
+        return self.__substitutions(self.TXT_TEMPLATE)
+
+    @property
+    def markdown(self):
+        return self.__substitutions(self.MD_TEMPLATE)

--- a/template-s2i.yaml
+++ b/template-s2i.yaml
@@ -26,6 +26,11 @@ parameters:
   description: Email address of the recipient
   required: true
 
+- name: OUTPUT_MARKDOWN
+  description: Send email attachment in Markdown format
+  value: false
+  required: false
+
 objects:
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig
@@ -49,6 +54,8 @@ objects:
         env:
         - name: EMAIL_RECIPIENT
           value: ${EMAIL_RECIPIENT}
+        - name: OUTPUT_MARKDOWN
+          value: ${OUTPUT_MARKDOWN}
         from:
           kind: ImageStreamTag
           name: python:3.9-ubi8

--- a/template-s2i.yaml
+++ b/template-s2i.yaml
@@ -26,7 +26,7 @@ parameters:
   description: Email address of the recipient
   required: true
 
-- name: OUTPUT_MARKDOWN
+- name: OUTPUT_IN_MARKDOWN
   description: Send email attachment in Markdown format
   value: false
   required: false
@@ -54,8 +54,8 @@ objects:
         env:
         - name: EMAIL_RECIPIENT
           value: ${EMAIL_RECIPIENT}
-        - name: OUTPUT_MARKDOWN
-          value: ${OUTPUT_MARKDOWN}
+        - name: OUTPUT_IN_MARKDOWN
+          value: ${OUTPUT_IN_MARKDOWN}
         from:
           kind: ImageStreamTag
           name: python:3.9-ubi8


### PR DESCRIPTION
Implement option to send email attachment formatted as Markdown. Additionally, parse the LinkChecker result via an XML file and Python's ElementTree instead of looping through the lines.

**These changes have not been tested in a cloud environment.**